### PR TITLE
feat/homeRequestPokeAPI: implement home request feature with PokeAPI …

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,0 +1,13 @@
+import { Routes } from '@angular/router';
+import { HomePage } from './home/home.page';
+
+export const routes: Routes = [
+  {
+    path: '',
+    component: HomePage,
+  },
+  {
+    path: 'details/:name',
+    loadComponent: () => import('./details/details.page').then(m => m.DetailsPage),
+  },
+];

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,16 +1,21 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
-  it('should create the app', async () => {
+
+  beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AppComponent],
-      providers: [provideRouter([])]
+      declarations: [AppComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
-    
+  });
+
+  it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });
+
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,11 +1,10 @@
 import { Component } from '@angular/core';
-import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
+import { RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'app-root',
-  templateUrl: 'app.component.html',
-  imports: [IonApp, IonRouterOutlet],
+  standalone: true,
+  imports: [RouterOutlet],
+  template: `<router-outlet></router-outlet>`
 })
-export class AppComponent {
-  constructor() {}
-}
+export class AppComponent { }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { AppComponent } from './app.component';
+
+@NgModule({
+  imports: [BrowserModule, AppComponent],
+  bootstrap: [AppComponent]               
+})
+export class AppModule { }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,13 +1,8 @@
 import { Routes } from '@angular/router';
+import { HomePage } from './home/home.page';
+import { DetailsPage } from './details/details.page';
 
 export const routes: Routes = [
-  {
-    path: 'home',
-    loadComponent: () => import('./home/home.page').then((m) => m.HomePage),
-  },
-  {
-    path: '',
-    redirectTo: 'home',
-    pathMatch: 'full',
-  },
+  { path: '', component: HomePage },
+  { path: 'details/:id', component: DetailsPage }
 ];

--- a/src/app/home/home-routing.module.ts
+++ b/src/app/home/home-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { HomePage } from './home.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: HomePage,
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class HomePageRoutingModule {}

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+import { HomePage } from './home.page';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    IonicModule,
+    HomePage
+  ],
+})
+export class HomePageModule {}

--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -1,20 +1,33 @@
-<ion-header [translucent]="true">
-  <ion-toolbar>
-    <ion-title>
-      Blank
-    </ion-title>
+<ion-header>
+  <ion-toolbar class="title-container" color="dark">
+    <ion-title class="header-title">Pokédex</ion-title>
   </ion-toolbar>
 </ion-header>
 
-<ion-content [fullscreen]="true">
-  <ion-header collapse="condense">
-    <ion-toolbar>
-      <ion-title size="large">Blank</ion-title>
-    </ion-toolbar>
-  </ion-header>
-
-  <div id="container">
-    <strong>Ready to create an app?</strong>
-    <p>Start with Ionic <a target="_blank" rel="noopener noreferrer" href="https://ionicframework.com/docs/components">UI Components</a></p>
+<ion-content class="ion-padding">
+  <div class="grid-container">
+    <div class="pokemon-card" *ngFor="let pokemon of pokemons" (click)="goToDetails(pokemon.name)">
+      <img [src]="pokemon.sprites.front_default" class="pokemon-img" />
+      <h2 class="pokemon-name">{{ pokemon.name | titlecase }}</h2>
+      <div class="pokemon-types">
+        <ion-chip *ngFor="let type of pokemon.types" [class]="'type-' + type.type.name">
+          <ion-label>{{ type.type.name | titlecase }}</ion-label>
+        </ion-chip>
+      </div>
+    </div>
   </div>
+
+  <div class="pagination">
+    <div class="arrow-button" [class.disabled]="currentPage === 1" (click)="prevPage()">
+      <ion-icon name="arrow-previus"></ion-icon>
+    </div>
+    <span *ngIf="pageNumbers[0] > 1">...</span>
+    <span *ngFor="let page of pageNumbers" class="page-number" [class.active]="currentPage === page"
+      (click)="goToPage(page)">{{ page }}</span>
+    <span *ngIf="pageNumbers[pageNumbers.length - 1] < totalPages">...</span>
+    <div class="arrow-button" [class.disabled]="currentPage === totalPages" (click)="nextPage()">
+      <ion-icon name="arrow-next"></ion-icon>
+    </div>
+  </div>
+
 </ion-content>

--- a/src/app/home/home.page.scss
+++ b/src/app/home/home.page.scss
@@ -1,27 +1,305 @@
-#container {
+.header-title {
   text-align: center;
-
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 50%;
-  transform: translateY(-50%);
+  font-size: 1.5rem;
+  padding: 10px 0;
 }
 
-#container strong {
-  font-size: 20px;
-  line-height: 26px;
+.pokemon-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  transition: transform 0.3s ease;
+  cursor: pointer;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+  border-radius: 12px;
+  background: #ffffff;
+  padding: 16px;
+  text-align: center;
 }
 
-#container p {
-  font-size: 16px;
-  line-height: 22px;
-
-  color: #8c8c8c;
-
-  margin: 0;
+.pokemon-card:hover {
+  transform: translateY(-5px);
 }
 
-#container a {
-  text-decoration: none;
+.pokemon-img {
+  width: 100px;
+  height: 100px;
+  object-fit: contain;
+  margin-top: 15px;
+  margin-bottom: 8px;
+}
+
+.pokemon-name {
+  text-align: center;
+  font-weight: bold;
+  font-size: 1.1rem;
+  margin-top: 10px;
+  margin-bottom: 6px;
+  color: #000000;
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  margin-top: 20px;
+  padding: 0 10px;
+  min-height: 60px;
+  visibility: visible;
+  margin-bottom: 70px;
+  padding-bottom: 20px;
+  position: relative;
+  z-index: 10;
+}
+
+.page-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: #ffffff;
+  color: #000000;
+  cursor: pointer;
+  font-weight: bold;
+  border: 1px solid #ccc;
+}
+
+.page-number.active {
+  background: #EE8130;
+  color: #ffffff;
+  border-color: #EE8130;
+}
+
+.page-number:hover {
+  background: #CC5F2E;
+  color: #ffffff;
+}
+
+.grid-container {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  max-width: 100%;
+  margin: auto;
+  padding: 15px;
+  min-height: 0;
+}
+
+.pokemon-types {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 5px;
+  color: #000000;
+}
+
+ion-chip {
+  --color: #ffffff;
+  --background: #ccc;
+  font-size: 0.75rem;
+  padding: 0 8px;
+  border-radius: 10px;
+}
+
+/* Cores dos tipos */
+.type-fire {
+  --background: #EE8130;
+}
+
+.type-water {
+  --background: #6390F0;
+}
+
+.type-grass {
+  --background: #7AC74C;
+}
+
+.type-electric {
+  --background: #F7D02C;
+}
+
+.type-ice {
+  --background: #96D9D6;
+}
+
+.type-fighting {
+  --background: #C22E28;
+}
+
+.type-poison {
+  --background: #A33EA1;
+}
+
+.type-ground {
+  --background: #E2BF65;
+}
+
+.type-flying {
+  --background: #A98FF3;
+}
+
+.type-psychic {
+  --background: #F95587;
+}
+
+.type-bug {
+  --background: #A6B91A;
+}
+
+.type-rock {
+  --background: #B6A136;
+}
+
+.type-ghost {
+  --background: #735797;
+}
+
+.type-dragon {
+  --background: #6F35FC;
+}
+
+.type-dark {
+  --background: #705746;
+}
+
+.type-steel {
+  --background: #B7B7CE;
+}
+
+.type-fairy {
+  --background: #D685AD;
+}
+
+.type-normal {
+  --background: #A8A77A;
+}
+
+ion-button {
+  --background: #EE8130;
+  --color: #ffffff;
+  --border-radius: 20px;
+  --box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  --padding-start: 15px;
+  --padding-end: 15px;
+}
+
+ion-button:hover {
+  --background: #CC5F2E;
+}
+
+ion-button:disabled {
+  --background: #cccccc;
+  --color: #666666;
+  opacity: 0.5;
+}
+
+/* Ajuste do ion-content */
+ion-content.ion-padding {
+  --padding-top: 0px !important;
+  --padding-bottom: 0px !important;
+  --offset-top: 0px !important;
+  --offset-bottom: 0px !important;
+  height: auto !important;
+  min-height: 100vh !important;
+  max-height: none !important;
+  display: block !important;
+  overflow: auto !important;
+  position: relative !important;
+  background: #000000;
+}
+
+/* Contêiner personalizado */
+.content-container {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background: #000000;
+  padding-bottom: 20px;
+}
+
+.grid-container {
+  flex-grow: 1;
+}
+
+/* Responsividade */
+@media (max-width: 1024px) {
+  .grid-container {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .grid-container {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .pokemon-img {
+    width: 80px;
+    height: 80px;
+  }
+
+  .pokemon-name {
+    font-size: 1rem;
+  }
+
+  .pagination {
+    flex-direction: column;
+    gap: 10px;
+    padding: 0 5px;
+  }
+
+  .page-number {
+    width: 25px;
+    height: 25px;
+    font-size: 0.9rem;
+  }
+
+  ion-button {
+    --padding-start: 10px;
+    --padding-end: 10px;
+  }
+}
+
+@media (max-width: 480px) {
+  .grid-container {
+    grid-template-columns: 1fr;
+  }
+
+  .pokemon-img {
+    width: 60px;
+    height: 60px;
+  }
+
+  .pokemon-name {
+    font-size: 0.9rem;
+  }
+
+  .pagination {
+    min-height: 40px;
+    padding-bottom: 10px;
+  }
+
+  .page-number {
+    width: 20px;
+    height: 20px;
+    font-size: 0.8rem;
+  }
+}
+
+.arrow-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 20px;
+  background: #EE8130;
+  color: #ffffff;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  transition: background 0.3s ease;
 }

--- a/src/app/home/home.page.spec.ts
+++ b/src/app/home/home.page.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { IonicModule } from '@ionic/angular';
 
 import { HomePage } from './home.page';
 
@@ -7,6 +8,11 @@ describe('HomePage', () => {
   let fixture: ComponentFixture<HomePage>;
 
   beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [HomePage],
+      imports: [IonicModule.forRoot()]
+    }).compileComponents();
+
     fixture = TestBed.createComponent(HomePage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -1,12 +1,98 @@
-import { Component } from '@angular/core';
-import { IonHeader, IonToolbar, IonTitle, IonContent } from '@ionic/angular/standalone';
+import { Component, OnInit } from '@angular/core';
+import { PokemonService } from '../services/pokemon/pokemon.service';
+import { Router } from '@angular/router';
+import { IonicModule } from '@ionic/angular';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-home',
-  templateUrl: 'home.page.html',
-  styleUrls: ['home.page.scss'],
-  imports: [IonHeader, IonToolbar, IonTitle, IonContent],
+  standalone: true,
+  imports: [CommonModule, IonicModule],
+  templateUrl: './home.page.html',
+  styleUrls: ['./home.page.scss'],
 })
-export class HomePage {
-  constructor() {}
+export class HomePage implements OnInit {
+  pokemons: any[] = [];
+  offset = 0;
+  limit = 20;
+  totalPokemons = 0;
+  currentPage = 1;
+  totalPages = 1;
+  pageNumbers: number[] = [];
+
+  constructor(
+    private pokemonService: PokemonService,
+    private router: Router
+  ) {}
+
+  ngOnInit() {
+    this.loadPokemons();
+  }
+
+  loadPokemons() {
+    this.pokemonService.getPokemons(this.offset, this.limit).subscribe({
+      next: (res) => {
+        this.totalPokemons = res.count;
+        this.totalPages = Math.ceil(this.totalPokemons / this.limit);
+        this.updatePageNumbers();
+        const requests = res.results.map((p: any) => this.pokemonService.getPokemonDetails(p.name));
+        Promise.all(requests.map((r: any) => r.toPromise())).then(data => {
+          this.pokemons = data;
+          console.log('Pokémon carregados:', this.pokemons.length, 'Página:', this.currentPage);
+        }).catch(err => {
+          console.error('Erro ao carregar detalhes:', err);
+        });
+      },
+      error: (err) => {
+        console.error('Erro ao buscar Pokémon:', err);
+      }
+    });
+  }
+
+  updatePageNumbers() {
+    const maxPagesToShow = 15;
+    const halfRange = Math.floor(maxPagesToShow / 2);
+    let startPage = this.currentPage - halfRange;
+    let endPage = this.currentPage + halfRange;
+
+    if (startPage < 1) {
+      startPage = 1;
+      endPage = Math.min(maxPagesToShow, this.totalPages);
+    }
+    if (endPage > this.totalPages) {
+      endPage = this.totalPages;
+      startPage = Math.max(1, endPage - maxPagesToShow + 1);
+    }
+
+    this.pageNumbers = Array.from({ length: endPage - startPage + 1 }, (_, i) => startPage + i);
+  }
+
+  goToPage(page: number) {
+    this.currentPage = page;
+    this.offset = (page - 1) * this.limit;
+    this.loadPokemons();
+    this.updatePageNumbers();
+  }
+
+  prevPage() {
+    if (this.currentPage > 1) {
+      this.currentPage--;
+      this.offset -= this.limit;
+      this.loadPokemons();
+      this.updatePageNumbers();
+    }
+  }
+
+  nextPage() {
+    if (this.currentPage < this.totalPages) {
+      this.currentPage++;
+      this.offset += this.limit;
+      this.loadPokemons();
+      this.updatePageNumbers();
+    }
+  }
+
+  goToDetails(name: string) {
+    this.router.navigate(['/details', name]);
+  }
 }

--- a/src/app/services/pokemon/pokemon.service.ts
+++ b/src/app/services/pokemon/pokemon.service.ts
@@ -1,0 +1,30 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable, catchError } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PokemonService {
+  private baseUrl = 'https://pokeapi.co/api/v2/pokemon';
+
+  constructor(private http: HttpClient) { }
+
+  getPokemons(offset = 0, limit = 20): Observable<any> {
+    return this.http.get<any>(`${this.baseUrl}?offset=${offset}&limit=${limit}`).pipe(
+      catchError(error => {
+        console.error('Erro ao buscar Pokémon:', error);
+        throw error;
+      })
+    );
+  }
+
+  getPokemonDetails(name: string): Observable<any> {
+    return this.http.get<any>(`${this.baseUrl}/${name}`).pipe(
+      catchError(error => {
+        console.error('Erro ao buscar detalhes do Pokémon:', error);
+        throw error;
+      })
+    );
+  }
+}

--- a/src/global.scss
+++ b/src/global.scss
@@ -34,4 +34,4 @@
 
 /* @import "@ionic/angular/css/palettes/dark.always.css"; */
 /* @import "@ionic/angular/css/palettes/dark.class.css"; */
-@import '@ionic/angular/css/palettes/dark.system.css';
+@import "@ionic/angular/css/palettes/dark.system.css";

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,35 @@
 import { bootstrapApplication } from '@angular/platform-browser';
-import { RouteReuseStrategy, provideRouter, withPreloading, PreloadAllModules } from '@angular/router';
-import { IonicRouteStrategy, provideIonicAngular } from '@ionic/angular/standalone';
-
-import { routes } from './app/app.routes';
+import { provideHttpClient } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
+import { provideIonicAngular } from '@ionic/angular/standalone';
 import { AppComponent } from './app/app.component';
+import { routes } from './app/app.routes';
 
 bootstrapApplication(AppComponent, {
   providers: [
-    { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
+    provideHttpClient(),
+    provideRouter(routes),
     provideIonicAngular(),
-    provideRouter(routes, withPreloading(PreloadAllModules)),
   ],
+}); import { enableProdMode } from '@angular/core';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+
+import { AppModule } from './app/app.module';
+import { environment } from './environments/environment';
+import { addIcons } from 'ionicons';
+import { heart, heartOutline, arrowBack, arrowForward } from 'ionicons/icons';
+
+if (environment.production) {
+  enableProdMode();
+}
+
+addIcons({
+  'heart': heart,
+  'heart-outline': heartOutline,
+  'arrow-next': arrowForward,
+  'arrow-previus': arrowBack,
 });
+
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
+  .catch(err => console.error(err));


### PR DESCRIPTION
Pull Request: Implementação da funcionalidade de listagem paginada de Pokémon
Descrição
Este pull request adiciona a funcionalidade de exibir uma lista paginada de Pokémon na página inicial, utilizando a PokeAPI para buscar os dados. Inclui a integração do serviço Pokémon para gerenciar chamadas de API, suporte a navegação entre páginas e redirecionamento para detalhes de cada Pokémon.
Mudanças Principais

Adição da página inicial (home.page.ts, home.page.html, home.page.scss) com lista paginada de Pokémon.
Implementação do serviço Pokémon (pokemon.service.ts) para buscar a lista de Pokémon e detalhes individuais.
Configuração de roteamento para a página inicial (home-routing.module.ts).
Atualização do arquivo principal (main.ts) para incluir dependências necessárias.
Inclusão de testes básicos (home.page.spec.ts).
Estilização responsiva com controles de paginação.

Testes

Verifique se a lista de Pokémon carrega corretamente na página inicial.
Teste a navegação entre páginas usando os controles de paginação.
Confirme o redirecionamento para a página de detalhes ao clicar em um Pokémon.
Teste a responsividade em diferentes tamanhos de tela.

Issues Relacionadas

Resolve #3: Criar lista paginada na página inicial
Resolve #4: Integrar serviço de Pokémon para chamadas de API

Próximos Passos

Adicionar filtros e busca na lista de Pokémon.
Melhorar os testes unitários.
Incluir animações na transição de páginas.

Revisão
Por favor, revise o código e sugira melhorias. Teste a aplicação localmente para validar as mudanças.
