### PR TITLE
fea/PageDetails: add details page with routing, template, styles, and…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# teste_pokemon_dex
+Aplicativo Pokémon Ionic
+Este é um aplicativo Ionic construído com Angular que permite aos usuários explorar dados de Pokémon usando a PokeAPI. O app inclui funcionalidades para visualizar uma lista paginada de Pokémon, navegar para detalhes, marcar favoritos e aproveitar uma interface no estilo Pokedex responsiva.
+Funcionalidades
+
+Exibe uma lista paginada de Pokémon com detalhes como nome e tipos.
+Navega para informações detalhadas de Pokémon, incluindo habilidades, estatísticas base, peso, altura e experiência base.
+Alterna Pokémon favoritos e os salva no armazenamento local.
+Design responsivo com uma interface temática de Pokedex.
+Controles de paginação para navegar pela lista de Pokémon.
+
+Instalação
+
+Certifique-se de ter Node.js e Angular CLI instalados.
+Clone o repositório: git clone <url-do-repositório>.
+Navegue até o diretório do projeto: cd pokemon-ionic-app.
+Instale as dependências: npm install.
+Adicione o Ionic CLI se ainda não estiver instalado: npm install -g @ionic/cli.
+Execute o app: ionic serve.
+
+Uso
+
+Veja a página inicial para acessar uma lista paginada de Pokémon.
+Clique em um Pokémon para visualizar informações detalhadas na página de detalhes.
+Use o botão de favorito para adicionar ou remover Pokémon da lista de favoritos.
+Navegue pelas páginas usando os controles de paginação na parte inferior da página inicial.
+
+Estrutura de Arquivos
+
+src/app/home/: Contém os componentes da página inicial, roteamento e estilos para a lista de Pokémon.
+src/app/details/: Contém os componentes da página de detalhes, roteamento e estilos.
+src/app/services/: Abriga o serviço de Pokémon para chamadas de API.
+src/app/app.module.ts: Módulo principal da aplicação.
+src/app/app-routing.module.ts: Configuração de roteamento da aplicação.
+src/main.ts: Configuração de bootstrap da aplicação e Ionic.
+
+Dependências
+
+@angular/core
+@angular/common
+@angular/router
+@ionic/angular
+@angular/common/http
+ionicons
+
+Contribuindo
+Sinta-se à vontade para enviar problemas ou pull requests. Certifique-se de seguir o estilo de código existente e incluir testes quando aplicável.
+Licença
+Este projeto é licenciado sob a Licença Apache-2.0.

--- a/src/app/details/details-routing.module.ts
+++ b/src/app/details/details-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { DetailsPage } from './details.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: DetailsPage
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class DetailsPageRoutingModule {}

--- a/src/app/details/details.module.ts
+++ b/src/app/details/details.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+import { DetailsPage } from './details.page';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    IonicModule,
+    DetailsPage
+  ],
+})
+export class DetailsPageModule { }

--- a/src/app/details/details.page.html
+++ b/src/app/details/details.page.html
@@ -1,0 +1,94 @@
+<ion-header>
+  <ion-toolbar color="primary">
+    <ion-buttons slot="start">
+      <ion-back-button defaultHref="/"></ion-back-button>
+    </ion-buttons>
+    <ion-title *ngIf="pokemon">{{ pokemon.name | titlecase }}</ion-title>
+    <ion-title *ngIf="!pokemon">Carregando...</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content class="ion-padding pokedex-device">
+  <ion-spinner *ngIf="isLoading" name="crescent" class="loading-spinner"></ion-spinner>
+
+  <div *ngIf="pokemon && !isLoading" class="main-container">
+    <div class="pokedex-body">
+      <div class="pokedex-top">
+        <div class="pokeball-decoration"></div>
+        <h2 class="pokedex-brand">Pokémon</h2>
+      </div>
+
+      <!-- Tela principal -->
+      <div class="pokedex-screen">
+        <div class="pokemon-display">
+          <img [src]="pokemon.sprites.other['official-artwork'].front_default" alt="Imagem de {{ pokemon.name }}"
+            class="pokemon-image" />
+          <img
+            src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/shiny/{{ pokemon.id }}.png"
+            alt="Shiny {{ pokemon.name }}" class="pokemon-shiny" *ngIf="pokemon.id" />
+          <h1 class="pokemon-name">{{ pokemon.name | titlecase }} <span>#{{ pokemon.id }}</span></h1>
+        </div>
+      </div>
+
+      <!-- Controles e botão de favoritar -->
+      <div class="pokedex-controls">
+        <div class="control-buttons">
+          <div class="button red"></div>
+          <div class="button green"></div>
+          <div class="button black"></div>
+        </div>
+        <ion-button (click)="toggleFavorite()" [color]="isFavorite ? 'danger' : 'success'" class="favorite-button">
+          <ion-icon slot="start" [name]="isFavorite ? 'heart' : 'heart-outline'"></ion-icon>
+        </ion-button>
+      </div>
+
+      <div class="pokedex-details">
+        <div class="detail-section">
+          <h3>Tipos</h3>
+          <div class="type-chips">
+            <ion-chip *ngFor="let type of pokemon.types" [color]="type.type.name" class="pokemon-type">
+              <ion-label>{{ type.type.name | titlecase }}</ion-label>
+            </ion-chip>
+          </div>
+        </div>
+
+        <div class="detail-section">
+          <h3>Habilidades</h3>
+          <ul class="ability-list">
+            <li *ngFor="let ability of pokemon.abilities">
+              {{ ability.ability.name | titlecase }}
+            </li>
+          </ul>
+        </div>
+
+        <div class="detail-section">
+          <h3>Status Base</h3>
+          <ion-list>
+            <ion-item *ngFor="let stat of pokemon.stats" class="stat-item">
+              <ion-label>{{ stat.stat.name | titlecase }}</ion-label>
+              <ion-badge color="secondary">{{ stat.base_stat }}</ion-badge>
+            </ion-item>
+          </ion-list>
+        </div>
+
+        <div class="detail-section">
+          <h3>Detalhes</h3>
+          <p><strong>Experiência base:</strong> {{ pokemon.base_experience }}</p>
+          <p><strong>Peso:</strong> {{ pokemon.weight / 10 }} kg</p>
+          <p><strong>Altura:</strong> {{ pokemon.height / 10 }} m</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="favorites-panel">
+      <h3>Favoritos</h3>
+      <ul class="favorite-list">
+        <li *ngFor="let favorite of favoritePokemons" (click)="goToFavoriteDetails(favorite.name)"
+          class="favorite-item">
+          {{ favorite.name | titlecase }} <span>#{{ favorite.id }}</span>
+        </li>
+        <li *ngIf="favoritePokemons.length === 0" class="no-favorites">Nenhum Pokémon favorito ainda.</li>
+      </ul>
+    </div>
+  </div>
+</ion-content>

--- a/src/app/details/details.page.scss
+++ b/src/app/details/details.page.scss
@@ -1,0 +1,344 @@
+.pokedex-device {
+  background: #ffffff;
+  min-height: 100vh;
+  padding: 20px 0;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  position: relative;
+}
+
+.loading-spinner {
+  display: block;
+  margin: 80px auto;
+  color: #ff4040;
+}
+
+.main-container {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  max-width: 1200px;
+  position: relative;
+}
+
+.pokedex-body {
+  background: #ff4040;
+  border-radius: 15px;
+  padding: 20px;
+  width: 100%;
+  max-width: 600px;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.5);
+  border: 2px solid #800000;
+  position: relative;
+  overflow: hidden;
+  margin: 0 auto;
+  margin-bottom: 50px;
+}
+
+.pokedex-top {
+  text-align: center;
+  padding: 10px 0;
+  background: #ffffff;
+  border-bottom: 2px solid #800000;
+  border-radius: 10px 10px 0 0;
+}
+
+.pokeball-decoration {
+  width: 50px;
+  height: 50px;
+  background: radial-gradient(circle at 30% 30%, #ffffff 0%, #ff4040 70%, #800000 100%);
+  border: 2px solid #000000;
+  border-radius: 50%;
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.5);
+}
+
+.pokedex-brand {
+  font-size: 20px;
+  color: #ff4040;
+  font-weight: bold;
+  margin-top: 50px;
+  text-shadow: 1px 1px 2px #800000;
+}
+
+.pokedex-screen {
+  background: #1e90ff;
+  border: 2px solid #ffffff;
+  border-radius: 5px;
+  padding: 25px;
+  margin: 30px 0;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.pokemon-display {
+  background: #000000;
+  padding: 15px;
+  border-radius: 5px;
+}
+
+.favorite-button {
+  --background: transparent;
+  --border-color: #ffffff;
+  --color: #ffffff;
+  --padding-start: 5px;
+  --padding-end: 5px;
+  margin-left: 10px;
+  height: 30px !important;
+  width: 30px !important;
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.favorite-button ion-icon {
+  font-size: 18px;
+  margin: 0;
+}
+
+.pokemon-image {
+  width: 250px;
+  height: auto;
+  display: block;
+  margin: 0 auto 15px;
+  border: 3px solid #ffffff;
+  border-radius: 5px;
+}
+
+.pokemon-shiny {
+  width: 100px;
+  height: auto;
+  position: absolute;
+  top: 30px;
+  right: 30px;
+  opacity: 0.7;
+  border: 2px solid #ffd700;
+  border-radius: 5px;
+}
+
+.pokemon-name {
+  font-size: 28px;
+  font-weight: bold;
+  color: #ffffff;
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.7);
+  margin: 15px 0;
+
+  span {
+    font-size: 18px;
+    color: #ffd700;
+    font-weight: normal;
+  }
+}
+
+.pokedex-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 15px 0;
+  background: #ffffff;
+  border-top: 2px solid #800000;
+  border-radius: 0 0 10px 10px;
+  position: relative;
+}
+
+.control-buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.button {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  &.red { background: #ff4040; }
+  &.green { background: #00ff00; }
+  &.black { background: #000000; }
+}
+
+.d-pad {
+  width: 40px;
+  height: 40px;
+  background: 
+    linear-gradient(45deg, #000000 25%, transparent 25%),
+    linear-gradient(-45deg, #000000 25%, transparent 25%),
+    linear-gradient(135deg, #000000 25%, transparent 25%),
+    linear-gradient(-135deg, #000000 25%, transparent 25%);
+  background-position: 0 0, 0 0, 20px 20px, 20px 20px;
+  background-size: 40px 40px;
+  background-repeat: no-repeat;
+}
+
+.pokedex-details {
+  background: rgba(0, 0, 0, 0.7);
+  border-radius: 10px;
+  padding: 20px;
+  margin-top: 20px;
+  border: 2px solid #ff4040;
+  max-width: 100%;
+}
+
+.detail-section {
+  margin-top: 15px;
+  text-align: left;
+}
+
+.detail-section h3 {
+  font-size: 18px;
+  margin-bottom: 10px;
+  color: #ff4040;
+  text-transform: uppercase;
+  border-bottom: 1px solid #ff4040;
+  padding-bottom: 5px;
+}
+
+.type-chips {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.pokemon-type {
+  margin-right: 0;
+  text-transform: capitalize;
+  font-weight: bold;
+  --background: #2a4066;
+  --color: #ffffff;
+}
+
+.ability-list {
+  list-style: none;
+  padding: 0;
+  li {
+    background: #2a4066;
+    padding: 5px 10px;
+    margin-bottom: 5px;
+    border-radius: 5px;
+    color: #ffffff;
+    border-left: 4px solid #ff4040;
+  }
+}
+
+.stat-item {
+  --background: #2a4066;
+  --color: #ffffff;
+  margin-bottom: 5px;
+  border-radius: 5px;
+  border-left: 4px solid #ff4040;
+}
+
+.detail-section p {
+  font-size: 14px;
+  color: #ddd;
+  margin: 5px 0;
+  strong {
+    color: #ff4040;
+  }
+}
+
+.favorites-panel {
+  background: #ffffff;
+  border-radius: 10px;
+  padding: 20px;
+  width: 300px;
+  max-height: 500px;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+  border: 2px solid #ff4040;
+  position: relative;
+  top: 100px;
+}
+
+.favorites-panel h3 {
+  font-size: 20px;
+  color: #ff4040;
+  margin-bottom: 10px;
+  text-align: center;
+}
+
+.favorite-list {
+  list-style: none;
+  padding: 0;
+  max-height: 350px;
+  overflow-y: auto;
+}
+
+.favorite-item {
+  background: #2a4066;
+  padding: 10px;
+  margin-bottom: 5px;
+  border-radius: 5px;
+  color: #ffffff;
+  cursor: pointer;
+  border-left: 4px solid #ff4040;
+}
+
+.favorite-item:hover {
+  background: #1e3a5f;
+}
+
+.no-favorites {
+  color: #666;
+  text-align: center;
+  padding: 10px;
+}
+
+/* Media Query para telas menores */
+@media (max-width: 1000px) {
+  .main-container {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .pokedex-body {
+    max-width: 90%;
+  }
+
+  .favorites-panel {
+    position: relative;
+    width: 90%;
+    margin-top: 20px;
+    right: auto;
+    top: auto;
+  }
+
+  .pokemon-image {
+    width: 180px;
+  }
+
+  .pokemon-shiny {
+    width: 90px;
+  }
+
+  .pokemon-name {
+    font-size: 22px;
+    span {
+      font-size: 14px;
+    }
+  }
+
+  .button {
+    width: 15px;
+    height: 15px;
+  }
+
+  .d-pad {
+    width: 30px;
+    height: 30px;
+    background-size: 30px 30px;
+    background-position: 0 0, 0 0, 15px 15px, 15px 15px;
+  }
+
+  .favorite-button {
+    height: 25px;
+    width: 25px;
+  }
+
+  .favorite-button ion-icon {
+    font-size: 16px; /* Ajuste proporcional para telas menores */
+  }
+}

--- a/src/app/details/details.page.spec.ts
+++ b/src/app/details/details.page.spec.ts
@@ -1,0 +1,17 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DetailsPage } from './details.page';
+
+describe('DetailsPage', () => {
+  let component: DetailsPage;
+  let fixture: ComponentFixture<DetailsPage>;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DetailsPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/details/details.page.ts
+++ b/src/app/details/details.page.ts
@@ -1,0 +1,79 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { IonicModule } from '@ionic/angular';
+import { CommonModule } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+
+@Component({
+  selector: 'app-details',
+  standalone: true,
+  imports: [CommonModule, IonicModule, RouterModule],
+  templateUrl: './details.page.html',
+  styleUrls: ['./details.page.scss'],
+})
+export class DetailsPage implements OnInit {
+  pokemon: any;
+  isLoading = true;
+  tipoTexto = '';
+  habilidadesTexto = '';
+  favoritePokemons: any[] = [];
+  isFavorite = false;
+
+  constructor(private route: ActivatedRoute, private http: HttpClient, private router: Router) {
+    const savedFavorites = localStorage.getItem('favoritePokemons');
+    if (savedFavorites) {
+      this.favoritePokemons = JSON.parse(savedFavorites);
+    }
+  }
+
+  ngOnInit() {
+    console.log('🟢 ngOnInit executado');
+    this.route.paramMap.subscribe(params => {
+      console.log('Parâmetros completos da rota:', params.keys, params.getAll('name'), params.getAll('id'));
+      const name = params.get('name') || params.get('id');
+      console.log('Nome do Pokémon na rota:', name);
+
+      if (name) {
+        this.http.get(`https://pokeapi.co/api/v2/pokemon/${name}`).subscribe({
+          next: (data: any) => {
+            this.pokemon = data;
+            this.tipoTexto = data.types.map((t: any) => t.type.name).join(', ');
+            this.habilidadesTexto = data.abilities.map((a: any) => a.ability.name).join(', ');
+            this.checkFavorite();
+            this.isLoading = false;
+          },
+          error: (err) => {
+            console.error('Erro ao buscar Pokémon:', err);
+            this.isLoading = false;
+          },
+        });
+      } else {
+        console.error('Parâmetro "name" ou "id" não encontrado na rota');
+        this.isLoading = false;
+      }
+    });
+  }
+
+  toggleFavorite() {
+    const pokemonData = { id: this.pokemon.id, name: this.pokemon.name };
+    const index = this.favoritePokemons.findIndex(p => p.id === this.pokemon.id);
+
+    if (index === -1) {
+      this.favoritePokemons.push(pokemonData);
+      this.isFavorite = true;
+    } else {
+      this.favoritePokemons.splice(index, 1);
+      this.isFavorite = false;
+    }
+
+    localStorage.setItem('favoritePokemons', JSON.stringify(this.favoritePokemons));
+  }
+
+  checkFavorite() {
+    this.isFavorite = this.favoritePokemons.some(p => p.id === this.pokemon.id);
+  }
+
+  goToFavoriteDetails(name: string) {
+    this.router.navigate(['/details', name.toLowerCase()]);
+  }
+}


### PR DESCRIPTION
Pull Request: Implementação da funcionalidade de detalhes de Pokémon
Descrição
Este pull request adiciona a funcionalidade de exibir detalhes de Pokémon na página de detalhes, utilizando a PokeAPI para buscar os dados. Inclui a integração do serviço Pokémon para gerenciar chamadas de API, suporte a informações como tipos, habilidades e estatísticas, além de funcionalidades de favoritar Pokémon com salvamento local.
Mudanças Principais

Adição da página de detalhes (details.page.ts, details.page.html, details.page.scss) com integração à PokeAPI.
Implementação do serviço Pokémon (pokemon.service.ts) para buscar detalhes individuais de Pokémon.
Configuração de roteamento para a página de detalhes (details-routing.module.ts).
Atualização do módulo e testes da página de detalhes (details.module.ts, details.page.spec.ts).
Estilização responsiva com interface no estilo Pokedex.

Testes

Verifique se os detalhes de um Pokémon são exibidos corretamente na página de detalhes.
Teste a funcionalidade de favoritar e desfavoritar Pokémon.
Confirme o salvamento dos favoritos no armazenamento local.
Teste a responsividade em diferentes tamanhos de tela.

Issues Relacionadas

Resolve #1: Implementar página de detalhes do Pokémon
Resolve #2: Adicionar funcionalidade de favoritos

Próximos Passos

Adicionar mais detalhes visuais, como imagens dinâmicas.
Melhorar os testes unitários.
Incluir validações de erro mais robustas.